### PR TITLE
Adapt to cljdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.2.2 - 2020-04-28
+### Changed
+ - Avoid to use the ":default" keyword in required package: allow cljdoc to work.
+
 ## 0.2.1 - 2020-04-07
 ### Fixed
  - Fix a security issue by updating minimist package dependency thanks to dependatbot.

--- a/project.clj
+++ b/project.clj
@@ -1,18 +1,18 @@
-(defproject frozar/roughcljs "0.2.1"
-  :description "Clojurescript wrapper around roughjs library"
-  :url "https://github.com/frozar/roughcljs"
-  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
-            :url "https://www.eclipse.org/legal/epl-2.0/"}
+(defproject frozar/roughcljs "0.2.2"
+   :description "Clojurescript wrapper around roughjs library"
+   :url "https://github.com/frozar/roughcljs"
+   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+             :url "https://www.eclipse.org/legal/epl-2.0/"}
 
-  :dependencies [[org.clojure/clojurescript "1.10.597" :scope "provided"]
-                 [hiccup "1.0.5"]
-                 [hickory "0.7.1"]
-                 [com.rpl/specter "1.1.3"]
-                 ]
+   :dependencies [[org.clojure/clojurescript "1.10.597" :scope "provided"]
+                  [hiccup "1.0.5"]
+                  [hickory "0.7.1"]
+                  [com.rpl/specter "1.1.3"]
+                  ]
 
-  :source-paths ["src/main"]
+   :source-paths ["src/main"]
 
-  :repositories
-  {"clojars" {:url "https://clojars.org/frozar"
-              :sign-releases false}}
-  )
+   :repositories
+   {"clojars" {:url "https://clojars.org/frozar"
+               :sign-releases false}}
+   )

--- a/src/main/roughcljs/core.cljs
+++ b/src/main/roughcljs/core.cljs
@@ -1,5 +1,5 @@
 (ns roughcljs.core
-  (:require ["roughjs/bin/rough" :default rough]
+  (:require ["roughjs/bin/rough" :rename {default rough}]
             [roughcljs.utils :as utils]
             [hickory.core :as hickory]
             )


### PR DESCRIPTION
Delete the use of shadow-cljs ":default" keyword.

This keyword is not standard and will not be supported by the main ClojureScript compiler. And so the ClojureScript parser doesn't digest this syntax, which make cljdoc trash during its analysis.